### PR TITLE
PHP 8.1+ return type compatibility error supression + composer update to v2

### DIFF
--- a/AbstractEmbeddedBehavior.php
+++ b/AbstractEmbeddedBehavior.php
@@ -91,9 +91,9 @@ abstract class AbstractEmbeddedBehavior extends Behavior
     {
         if ($this->checkName($name)) {
             return $this->storage;
-        } else {
-            return parent::__get($name);
         }
+
+        return parent::__get($name);
     }
 
     public function __set($name, $value)

--- a/EmbeddedDocument.php
+++ b/EmbeddedDocument.php
@@ -33,6 +33,7 @@ class EmbeddedDocument extends Model
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function formName()
     {
         if (!empty($this->_formName)) {
@@ -45,6 +46,7 @@ class EmbeddedDocument extends Model
     /**
      * @param $formName
      */
+    #[\ReturnTypeWillChange]
     public function setFormName($formName)
     {
         if (!empty($formName)) {
@@ -56,6 +58,7 @@ class EmbeddedDocument extends Model
      * set link to primary model
      * @param ActiveRecord $model
      */
+    #[\ReturnTypeWillChange]
     public function setPrimaryModel(ActiveRecord $model)
     {
         $this->_primaryModel = $model;
@@ -66,6 +69,7 @@ class EmbeddedDocument extends Model
      * @return ActiveRecord
      * @throws UnknownPropertyException
      */
+    #[\ReturnTypeWillChange]
     public function getPrimaryModel()
     {
         if (!isset($this->_primaryModel)) {
@@ -79,6 +83,7 @@ class EmbeddedDocument extends Model
      * set link to primary model attribute
      * @param $value
      */
+    #[\ReturnTypeWillChange]
     public function setSource($value)
     {
         $this->_source = $value;
@@ -88,6 +93,7 @@ class EmbeddedDocument extends Model
      * Save embedded model as attribute on primary model
      * @throws UnknownPropertyException
      */
+    #[\ReturnTypeWillChange]
     public function save()
     {
         if (!isset($this->_source) || !$this->primaryModel->hasAttribute($this->_source)) {
@@ -96,6 +102,7 @@ class EmbeddedDocument extends Model
         $this->primaryModel->save(false, [$this->_source]);
     }
 
+    #[\ReturnTypeWillChange]
     public function setScenario($scenario)
     {
         if (array_key_exists($scenario, $this->scenarios())) {
@@ -111,6 +118,7 @@ class EmbeddedDocument extends Model
      * Пустым считается объект все атрибуты которого пусты (empty($value)) или равны значениям по-умолчанию. Не учитывает параметры "when" и "isEmpty" валидаторов "по-умолчанию".
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function isEmpty()
     {
         $notEmptyAttributes = [];

--- a/EmbedsManyBehavior.php
+++ b/EmbedsManyBehavior.php
@@ -15,18 +15,20 @@ class EmbedsManyBehavior extends AbstractEmbeddedBehavior
 {
     public $initEmptyScenarios = [];
 
+    #[\ReturnTypeWillChange]
     public function getFormName($index)
     {
         if ($this->setFormName) {
             return Html::getInputName($this->owner, $this->fakeAttribute."[{$index}]");
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     protected function setAttributes($attributes, $safeOnly = true)
     {
         $this->storage->removeAll();
@@ -51,6 +53,7 @@ class EmbedsManyBehavior extends AbstractEmbeddedBehavior
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     protected function getAttributes()
     {
         return $this->storage->attributes;
@@ -59,6 +62,7 @@ class EmbedsManyBehavior extends AbstractEmbeddedBehavior
     /**
      * @return Storage
      */
+    #[\ReturnTypeWillChange]
     public function getStorage()
     {
         if (empty($this->_storage)) {

--- a/EmbedsOneBehavior.php
+++ b/EmbedsOneBehavior.php
@@ -11,6 +11,7 @@ use yii\helpers\Html;
  */
 class EmbedsOneBehavior extends AbstractEmbeddedBehavior
 {
+    #[\ReturnTypeWillChange]
     protected function setAttributes($attributes, $safeOnly = true)
     {
         $this->storage->scenario = $this->owner->scenario;
@@ -20,18 +21,20 @@ class EmbedsOneBehavior extends AbstractEmbeddedBehavior
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     protected function getAttributes()
     {
         if ($this->saveEmpty || !$this->storage->isEmpty()) {
             return $this->storage->attributes;
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**
      * @return EmbeddedDocument
      */
+    #[\ReturnTypeWillChange]
     public function getStorage()
     {
         if (empty($this->_storage)) {

--- a/Storage.php
+++ b/Storage.php
@@ -17,6 +17,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
 
     private $_cursor = 0;
 
+    #[\ReturnTypeWillChange]
     public function removeAll()
     {
         $this->_container = [];
@@ -27,6 +28,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
      * @param string $name
      * @param Event $event
      */
+    #[\ReturnTypeWillChange]
     public function trigger($name, Event $event = null)
     {
         parent::trigger($name, $event);
@@ -39,6 +41,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function validate()
     {
         $hasError = false;
@@ -54,6 +57,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
     public function getAttributes()
     {
         $attributes = [];
@@ -69,6 +73,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
      * @param $condition
      * @return null| EmbeddedDocument
      */
+    #[\ReturnTypeWillChange]
     public function get($condition)
     {
         list($attribute, $value) = $condition;
@@ -87,6 +92,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
      * @param $object
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function set($condition, $object)
     {
         list($attribute, $value) = $condition;
@@ -100,6 +106,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
         return false;
     }
 
+    #[\ReturnTypeWillChange]
     public function sort($field)
     {
         $attributes = $this->attributes;
@@ -111,6 +118,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
         });
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $model)
     {
         if (is_null($offset)) {
@@ -120,6 +128,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
         $this->_container[$offset] = $model;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->valid($this->_cursor)) {
@@ -129,47 +138,56 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_cursor;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->_cursor;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_cursor = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->offsetExists($this->_cursor);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_container[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_container[$offset]);
         $this->_container = array_values($this->_container);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->_container[$offset]) ? $this->_container[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_container);
     }
 
+    #[\ReturnTypeWillChange]
     public function getNextIndex()
     {
         $count = count($this->_container);
@@ -181,6 +199,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
      * @param string $scenario
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function setScenario($scenario)
     {
         foreach ($this->_container as $model) {
@@ -189,6 +208,7 @@ class Storage extends Component implements StorageInterface, \Countable, \Iterat
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return '';

--- a/StorageInterface.php
+++ b/StorageInterface.php
@@ -14,7 +14,7 @@ interface StorageInterface extends \ArrayAccess
     /**
      * Triggers an event
      * @param string $name the event name
-     * @param Event $event the event parameter. If not set, a default [[Event]] object will be created.
+     * @param Event|null $event the event parameter. If not set, a default [[Event]] object will be created.
      */
     public function trigger($name, Event $event = null);
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,15 @@
         "yiisoft/yii2-codeception": "*",
         "codeception/codeception": "*"
     },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer" : true
+        },
+        "process-timeout": 1800,
+        "fxp-asset": {
+            "enabled": false
+        }
+    },
     "autoload": {
         "psr-4": {
             "consultnn\\embedded\\": "."
@@ -30,5 +39,11 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ]
 }


### PR DESCRIPTION
+ switching composer to use composer v2 instead of the old one
+ Fix in PHP 8.1, 8.2 for the following error: `[Reference: Return type of ... should either be compatible with ..., or the #[\ReturnTypeWillChange] attribute should be used](https://stackoverflow.com/questions/71133749/reference-return-type-of-should-either-be-compatible-with-or-the-re)`. 
This update will only suppress the deprecation error, which is backwards compatible with the old PHP versions as well. 
As of PHP 9 the return types will have to be declared, meaning that support have to drop for <7.0 PHP versions.